### PR TITLE
Force Ribbon on non-debugable variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ local.properties
 build/
 reports/
 gradle.properties
+*.iml

--- a/README.md
+++ b/README.md
@@ -27,11 +27,17 @@ android {
     // ...
 
     buildTypes {
-        debug {}
+        debug {/*debuggable build, which will ribbonized automatically*/}
         beta {
+            //debuggable build which will automatically ribbonized.
             debuggable true
         }
-        release {}
+        canary {
+            //non-debuggable build which will no automatically ribbonized.
+            //But, we force one of its flavors. See `ribbonizer` for how-to
+            debuggable false
+        }
+        release {/*non-debuggable build. Will not be rebbonized automatically*/}
     }
 
     productFlavors {
@@ -55,6 +61,10 @@ ribbonizer {
             return greenRibbonFilter(variant, iconFile)
         }
     }
+
+    //Although `canary` build-type is marked as `non-debuggable`
+    //we can still force specific variants to be ribbonized:
+    forcedVariantsNames "localCanary"
 }
 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
 

--- a/example-custom/build.gradle
+++ b/example-custom/build.gradle
@@ -24,6 +24,9 @@ android {
         beta {
             debuggable true
         }
+        canary {
+            debuggable false
+        }
         release {}
     }
 
@@ -46,6 +49,8 @@ ribbonizer {
             return greenRibbonFilter(variant, iconFile)
         }
     }
+
+    forcedVariantsNames "localCanary"
 }
 
 dependencies {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -27,7 +27,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'com.android.tools.build:gradle:2.0.0'
+    compile 'com.android.tools.build:gradle:2.1.2'
 
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude group:'org.codehaus.groovy'

--- a/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerExtension.java
+++ b/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerExtension.java
@@ -21,6 +21,8 @@ class RibbonizerExtension {
 
     public static String NAME = "ribbonizer";
 
+    Set<String> forcedVariantsNames = new HashSet<>();
+
     Set<String> iconNames = new HashSet<>();
 
     List<FilterBuilder> filterBuilders = new ArrayList<>();
@@ -58,6 +60,14 @@ class RibbonizerExtension {
      */
     public void iconName(String resName) {
         iconNames.add(resName);
+    }
+
+    public Set<String> getForcedVariantsNames() {
+        return forcedVariantsNames;
+    }
+
+    public void forcedVariantsNames(String... variantsNames) {
+        forcedVariantsNames = new HashSet<>(Arrays.asList(variantsNames));
     }
 
     public List<FilterBuilder> getFilterBuilders() {

--- a/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerPlugin.groovy
+++ b/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerPlugin.groovy
@@ -47,9 +47,8 @@ public class RibbonizerPlugin implements Plugin<Project> {
             def tasks = new ArrayList<Task>();
 
             android.applicationVariants.all { ApplicationVariant variant ->
-                if (!variant.buildType.debuggable) {
-                    project.logger.
-                            info("[ribbonizer] skip ${variant.name} because it is not debuggable.")
+                if ((!variant.buildType.debuggable) && (!extension.forcedVariantsNames.contains(variant.name))) {
+                    project.logger.info("[ribbonizer] skip ${variant.name} because it is not debuggable and not forced.")
                     return;
                 }
 


### PR DESCRIPTION
https://github.com/AnySoftKeyboard/AnySoftKeyboard has a _CANARY_ build-type which is a release build (non-debugable, proguarded, signed etc.), and is released to users.
This PR will allow this _canary_ build-type to be ribbonized.
