### PR TITLE
Added support for android:roundIcon launcher images

### DIFF
--- a/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/Resources.java
+++ b/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/Resources.java
@@ -4,11 +4,15 @@ import org.xml.sax.SAXException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
 
 import groovy.util.XmlSlurper;
 import groovy.util.slurpersupport.GPathResult;
+
+import static java.util.Collections.unmodifiableList;
 
 public class Resources {
 
@@ -28,10 +32,23 @@ public class Resources {
         }
     }
 
-    public static String getLauncherIcon(File manifestFile)
+    public static List<String> getLauncherIcons(File manifestFile)
             throws SAXException, ParserConfigurationException, IOException {
         GPathResult manifestXml = new XmlSlurper().parse(manifestFile);
         GPathResult applicationNode = (GPathResult) manifestXml.getProperty("application");
-        return String.valueOf(applicationNode.getProperty("@android:icon"));
+
+        String icon = String.valueOf(applicationNode.getProperty("@android:icon"));
+        String roundIcon = String.valueOf(applicationNode.getProperty("@android:roundIcon"));
+
+        List<String> icons = new ArrayList<>(2);
+        if (!icon.isEmpty()) {
+            icons.add(icon);
+        }
+        if (!roundIcon.isEmpty()) {
+            icons.add(roundIcon);
+        }
+
+        return unmodifiableList(icons);
+
     }
 }

--- a/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerTask.groovy
+++ b/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerTask.groovy
@@ -86,7 +86,7 @@ class RibbonizerTask extends DefaultTask {
     Set<String> getLauncherIconNames() {
         def names = new HashSet<String>()
         androidManifestFiles.forEach { File manifestFile ->
-            names.add(Resources.getLauncherIcon(manifestFile))
+            names.addAll(Resources.getLauncherIcons(manifestFile))
         }
         return names
     }

--- a/plugin/src/test/groovy/com/github/gfx/ribbonizer/test/ResourcesTest.groovy
+++ b/plugin/src/test/groovy/com/github/gfx/ribbonizer/test/ResourcesTest.groovy
@@ -9,13 +9,12 @@ public class ResourcesTest extends Specification {
         Resources.resourceFilePattern(resName) == pattern
 
         where:
-        resName | pattern
+        resName                 | pattern
         "@drawable/ic_launcher" | "drawable*/ic_launcher.*"
-        "@mipmap/icon" | "mipmap*/icon.*"
+        "@mipmap/icon"          | "mipmap*/icon.*"
     }
 
-
-    def "getgetLauncherIcon"() {
+    def "getLauncherIcon without android:roundIcon"() {
         setup:
         def file = File.createTempFile("AndroidManifest", ".xml")
         file.deleteOnExit()
@@ -38,6 +37,59 @@ public class ResourcesTest extends Specification {
 '''.trim())
 
         expect:
-        Resources.getLauncherIcon(file) == "@drawable/ic_launcher"
+        Resources.getLauncherIcons(file).containsAll(["@drawable/ic_launcher"])
+    }
+
+    def "getLauncherIcon without android:icon"() {
+        setup:
+        def file = File.createTempFile("AndroidManifest", ".xml")
+        file.deleteOnExit()
+        file.write('''
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.github.gfx.ribbonizer.example"
+    android:versionCode="1"
+    android:versionName="1.0" >
+    <uses-sdk
+        android:minSdkVersion="15"
+        android:targetSdkVersion="23" />
+    <application
+        android:allowBackup="true"
+        android:roundIcon="@drawable/ic_launcher_round"
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme" >
+    </application>
+</manifest>
+'''.trim())
+
+        expect:
+        Resources.getLauncherIcons(file).containsAll(["@drawable/ic_launcher_round"])
+    }
+
+    def "getLauncherIcon with both android:icon and android:roundIcon"() {
+        setup:
+        def file = File.createTempFile("AndroidManifest", ".xml")
+        file.deleteOnExit()
+        file.write('''
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.github.gfx.ribbonizer.example"
+    android:versionCode="1"
+    android:versionName="1.0" >
+    <uses-sdk
+        android:minSdkVersion="15"
+        android:targetSdkVersion="23" />
+    <application
+        android:allowBackup="true"
+        android:icon="@drawable/ic_launcher"
+        android:roundIcon="@drawable/ic_launcher_round"
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme" >
+    </application>
+</manifest>
+'''.trim())
+
+        expect:
+        Resources.getLauncherIcons(file).containsAll(["@drawable/ic_launcher", "@drawable/ic_launcher_round"])
     }
 }


### PR DESCRIPTION
As the title states, this PR adds "android:roundIcon" to the library's default set of processed images. I have modified `Resources#getLauncherIcon` to return a list of icons instead, which now accounts for absent properties in the manifest as well.