### PR TITLE
Exclude XML Resources from being processed by RibbonizerTask

### DIFF
--- a/example-custom/build.gradle
+++ b/example-custom/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.github.gfx.ribbonizer'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.0'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }

--- a/example-custom/src/main/res/drawable-v26/ic_launcher_foreground.xml
+++ b/example-custom/src/main/res/drawable-v26/ic_launcher_foreground.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:aapt="http://schemas.android.com/aapt"
+       android:inset="24dp">
+
+    <aapt:attr name="android:drawable">
+        <vector xmlns:android="http://schemas.android.com/apk/res/android"
+                android:height="24dp"
+                android:width="24dp"
+                android:viewportWidth="24"
+                android:viewportHeight="24">
+            <path android:fillColor="#fff"
+                  android:pathData="M15,5H14V4H15M10,5H9V4H10M15.53,2.16L16.84,0.85C17.03,0.66 17.03,0.34 16.84,0.14C16.64,-0.05 16.32,-0.05 16.13,0.14L14.65,1.62C13.85,1.23 12.95,1 12,1C11.04,1 10.14,1.23 9.34,1.63L7.85,0.14C7.66,-0.05 7.34,-0.05 7.15,0.14C6.95,0.34 6.95,0.66 7.15,0.85L8.46,2.16C6.97,3.26 6,5 6,7H18C18,5 17,3.25 15.53,2.16M20.5,8A1.5,1.5 0 0,0 19,9.5V16.5A1.5,1.5 0 0,0 20.5,18A1.5,1.5 0 0,0 22,16.5V9.5A1.5,1.5 0 0,0 20.5,8M3.5,8A1.5,1.5 0 0,0 2,9.5V16.5A1.5,1.5 0 0,0 3.5,18A1.5,1.5 0 0,0 5,16.5V9.5A1.5,1.5 0 0,0 3.5,8M6,18A1,1 0 0,0 7,19H8V22.5A1.5,1.5 0 0,0 9.5,24A1.5,1.5 0 0,0 11,22.5V19H13V22.5A1.5,1.5 0 0,0 14.5,24A1.5,1.5 0 0,0 16,22.5V19H17A1,1 0 0,0 18,18V8H6V18Z"/>
+        </vector>
+    </aapt:attr>
+</inset>

--- a/example-custom/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/example-custom/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <background android:drawable="@color/ic_launcher_background"/>
+</adaptive-icon>

--- a/example-custom/src/main/res/values-v26/colors.xml
+++ b/example-custom/src/main/res/values-v26/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#1c7917</color>
+</resources>

--- a/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerTask.groovy
+++ b/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerTask.groovy
@@ -53,6 +53,7 @@ class RibbonizerTask extends DefaultTask {
                 project.fileTree(
                         dir: resDir,
                         include: Resources.resourceFilePattern(name),
+                        exclude: "**/*.xml",
                 ).forEach { File inputFile ->
                     info "process $inputFile"
 


### PR DESCRIPTION
Right now, RibbonizerTask fails with an NPE when trying to apply filters to a non-image resource, such as Android O's `<adaptive-icon>` resources:

<details><summary>Stack Trace</summary>

```
[ribbonizeLocalDebug] process /workspace/gradle-android-ribbonizer-plugin/example-custom/src/main/res/drawable-hdpi/ic_launcher.png
[ribbonizeLocalDebug] process /workspace/gradle-android-ribbonizer-plugin/example-custom/src/main/res/drawable-mdpi/ic_launcher.png
[ribbonizeLocalDebug] process /workspace/gradle-android-ribbonizer-plugin/example-custom/src/main/res/drawable-xhdpi/ic_launcher.png
[ribbonizeLocalDebug] process /workspace/gradle-android-ribbonizer-plugin/example-custom/src/main/res/drawable-xxhdpi/ic_launcher.png
[ribbonizeLocalDebug] process /workspace/gradle-android-ribbonizer-plugin/example-custom/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
:example-custom:ribbonizeLocalDebug FAILED

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':example-custom:ribbonizeLocalDebug'.
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:69)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:46)
        ...
Caused by: java.lang.NullPointerException
	at com.github.gfx.ribbonizer.filter.ColorRibbonFilter.accept(ColorRibbonFilter.java:52)
	at com.github.gfx.ribbonizer.filter.ColorRibbonFilter.accept(ColorRibbonFilter.java:10)
	at com.github.gfx.ribbonizer.plugin.Ribbonizer$1.accept(Ribbonizer.java:35)
	at com.github.gfx.ribbonizer.plugin.Ribbonizer$1.accept(Ribbonizer.java:32)
	at com.github.gfx.ribbonizer.plugin.Ribbonizer.process(Ribbonizer.java:32)
        ...
```

</details>

<br/>

 Typically, this kind of "new launcher icon" is implemented inside of resource directories specific to `-v26`, but keeping the same name as pre-O resources. Therefore, when the launcher icon is normally named `mipmap-<dpi>/ic_launcher.png`, and then overridden on Android O with the adaptive icon at `mipmap-anydpi-v26/ic_launcher.xml`, `ImageIO` can't extract a `BufferedImage` out of that file and fails later on.

I've put a lot of thought into how Ribbonizer would be able to add ribbons to XML resources automatically, but to no avail. Ideally, that solution would also include `<vector>`/SVG resources. 

For now, we should simply exclude XML altogether, though, in order to prevent people from using Ribbonizer after upgrading their app to Android O.