### PR TITLE
Support Kotlin DSL friendly interface

### DIFF
--- a/plugin/src/main/groovy/com/github/gfx/ribbonizer/filter/ColorRibbonFilter.java
+++ b/plugin/src/main/groovy/com/github/gfx/ribbonizer/filter/ColorRibbonFilter.java
@@ -15,13 +15,13 @@ public class ColorRibbonFilter implements Consumer<BufferedImage> {
 
     final Color labelColor;
 
-    String label;
+    public String label;
 
-    String fontName = "Default";
+    public String fontName = "Default";
 
-    int fontStyle = Font.PLAIN;
+    public int fontStyle = Font.PLAIN;
 
-    boolean largeRibbon = false;
+    public boolean largeRibbon = false;
 
     public ColorRibbonFilter(String label, Color ribbonColor, Color labelColor) {
         this.label = label;

--- a/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerExtension.java
+++ b/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerExtension.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
-class RibbonizerExtension {
+public class RibbonizerExtension {
 
     public static String NAME = "ribbonizer";
 

--- a/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerExtension.java
+++ b/plugin/src/main/groovy/com/github/gfx/ribbonizer/plugin/RibbonizerExtension.java
@@ -7,6 +7,8 @@ import com.github.gfx.ribbonizer.GrayScaleBuilder;
 import com.github.gfx.ribbonizer.GrayRibbonBuilder;
 import com.github.gfx.ribbonizer.GreenRibbonBuilder;
 import com.github.gfx.ribbonizer.YellowRibbonBuilder;
+import com.github.gfx.ribbonizer.filter.ColorRibbonFilter;
+import com.github.gfx.ribbonizer.filter.GrayScaleFilter;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -87,23 +89,23 @@ public class RibbonizerExtension {
 
     // utilities
 
-    public Consumer<BufferedImage> grayScaleFilter(ApplicationVariant variant, File iconFile) {
-        return new GrayScaleBuilder().apply(variant, iconFile);
+    public GrayScaleFilter grayScaleFilter(ApplicationVariant variant, File iconFile) {
+        return (GrayScaleFilter) new GrayScaleBuilder().apply(variant, iconFile);
     }
 
-    public Consumer<BufferedImage> grayRibbonFilter(ApplicationVariant variant, File iconFile) {
-        return new GrayRibbonBuilder().apply(variant, iconFile);
+    public ColorRibbonFilter grayRibbonFilter(ApplicationVariant variant, File iconFile) {
+        return (ColorRibbonFilter) new GrayRibbonBuilder().apply(variant, iconFile);
     }
 
-    public Consumer<BufferedImage> yellowRibbonFilter(ApplicationVariant variant, File iconFile) {
-        return new YellowRibbonBuilder().apply(variant, iconFile);
+    public ColorRibbonFilter yellowRibbonFilter(ApplicationVariant variant, File iconFile) {
+        return (ColorRibbonFilter) new YellowRibbonBuilder().apply(variant, iconFile);
     }
 
-    public Consumer<BufferedImage> greenRibbonFilter(ApplicationVariant variant, File iconFile) {
-        return new GreenRibbonBuilder().apply(variant, iconFile);
+    public ColorRibbonFilter greenRibbonFilter(ApplicationVariant variant, File iconFile) {
+        return (ColorRibbonFilter) new GreenRibbonBuilder().apply(variant, iconFile);
     }
 
-    public Consumer<BufferedImage> customColorRibbonFilter(ApplicationVariant variant, File iconFile, String nm) {
-        return new CustomColorRibbonBuilder(nm).apply(variant, iconFile);
+    public ColorRibbonFilter customColorRibbonFilter(ApplicationVariant variant, File iconFile, String nm) {
+        return (ColorRibbonFilter) new CustomColorRibbonBuilder(nm).apply(variant, iconFile);
     }
 }


### PR DESCRIPTION
Fixes #28 

Gradle Kotlin DSL automatically generates accessors for each `Extension` for static type-safe access, but it didn't play well with Ribonizer because `RibobonizerExtension` was not public, as described at #28 .

Also, I've modified some codes where depends on Groovy's runtime dynamic type resolution. For utilities like `grayRibbonFilter()`, I've specified implementation classes like `ColorRibbonFilter` instead of `Consumer<BufferedImage>` to enable access to options.

With this change, you can use Ribbonizer in Kotlin DSL, like:

```kotlin
ribbonizer {
    builder { variant, iconFile ->
        when (variant.buildType.name) {
            "debug" -> yellowRibbonFilter(variant, iconFile).apply { label = branchName }
            else -> grayRibbonFilter(variant, iconFile)
        }
    }
}
```
